### PR TITLE
Fix appending attributes instead of inserting them

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -252,7 +252,27 @@ fn strike_through_attributes(
         }
     });
 
-    strike_attrs.iter().for_each(|attr| dec_attrs.insert(0, attr.clone()));
+    let (mut derive_attrs, rest_attrs) =
+        strike_attrs
+        .iter()
+        .fold((Vec::new(), Vec::new()),
+              | (mut der, mut rest), i| {
+                  if matches!(&i.path[0], TokenTree::Ident(token) if token == "derive") {
+                      der.push(i.clone());
+                  } else {
+                      rest.push(i.clone());
+                  }
+                  (der, rest)
+        });
+
+    // place other attrs after the existing ones
+    dec_attrs.extend_from_slice(&rest_attrs[..]);
+
+    // insert derive attrs before attributes
+    derive_attrs
+        .drain(..)
+        .for_each(|attr| dec_attrs.insert(0, attr));
+
 }
 
 fn recurse_through_type_list(

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -254,16 +254,15 @@ fn strike_through_attributes(
 
     let (mut derive_attrs, rest_attrs) =
         strike_attrs
-        .iter()
-        .fold((Vec::new(), Vec::new()),
-              | (mut der, mut rest), i| {
-                  if matches!(&i.path[0], TokenTree::Ident(token) if token == "derive") {
-                      der.push(i.clone());
-                  } else {
-                      rest.push(i.clone());
-                  }
-                  (der, rest)
-        });
+            .iter()
+            .fold((Vec::new(), Vec::new()), |(mut der, mut rest), i| {
+                if matches!(&i.path[0], TokenTree::Ident(token) if token == "derive") {
+                    der.push(i.clone());
+                } else {
+                    rest.push(i.clone());
+                }
+                (der, rest)
+            });
 
     // place other attrs after the existing ones
     dec_attrs.extend_from_slice(&rest_attrs[..]);
@@ -272,7 +271,6 @@ fn strike_through_attributes(
     derive_attrs
         .drain(..)
         .for_each(|attr| dec_attrs.insert(0, attr));
-
 }
 
 fn recurse_through_type_list(

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -251,7 +251,8 @@ fn strike_through_attributes(
             true
         }
     });
-    dec_attrs.extend_from_slice(&strike_attrs[..]);
+
+    strike_attrs.iter().for_each(|attr| dec_attrs.insert(0, attr.clone()));
 }
 
 fn recurse_through_type_list(

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,6 +12,7 @@ fn check(nested: proc_macro2::TokenStream, planexpected: proc_macro2::TokenStrea
 #[test]
 fn strikethrough_derive() {
     let from = quote! {
+        #[strikethrough[striked_attr]]
         #[strikethrough[derive(Debug, Default, PartialEq)]]
         #[gubbel]
         struct Parent {
@@ -22,19 +23,23 @@ fn strikethrough_derive() {
             e: u32,
         }
     };
+
     let out = quote! {
         #[derive(Debug, Default, PartialEq)]
+        #[striked_attr]
         struct Shared {
             d: i32
         }
-        #[gobbel]
         #[derive(Debug, Default, PartialEq)]
+        #[gobbel]
+        #[striked_attr]
         struct A {
             b: Shared,
             c: Shared,
         }
-        #[gubbel]
         #[derive(Debug, Default, PartialEq)]
+        #[gubbel]
+        #[striked_attr]
         struct Parent {
             a: A,
             e: u32,


### PR DESCRIPTION
This fixes a warning (`legacy_derive_helpers`) about outer struct attributes being used before being declared. This warning is slated to become a hard error in the future.

Trying to use outer struct attributes with `strikethrough` work, but seems like it may fail in the future.

Trying to compile a minimal example shows:
```
warning: derive helper attribute is used before it is introduced
 --> src/main.rs:8:11
  |
4 |     #[strikethrough[derive(Debug, Serialize, Deserialize)]]
  |                                   --------- the attribute is introduced here
...
8 |         #[serde(transparent)]
  |           ^^^^^
  |
  = note: `#[warn(legacy_derive_helpers)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
```

Indicating probably that it adds the `#[derive(Attr)]` after the outer attributes.

Tracking issue: https://github.com/rust-lang/rust/issues/79202

