### PR TITLE
Add the capability of skipping strikethrough for subtrees

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,25 +200,28 @@
 //! ```
 //!
 //! The behavior of `each` can be influenced in two ways:
-//!  * `structstruck::exclude_each` will ignore any attributes in `each`.
-//!    The order of attributes does not influence `exclude_each`.
-//!  * `structstruck::clear_each` will reset the set of attributes.
-//!    The order of atttributes matters.
-//!    After using `clear_each`, new attributes can be added.
+//!  * `structstruck::exclude_each` will ignore any attributes in `each` for the current struct only.
+//!  * `structstruck::clear_each` will ignore any `structstruck::each` from parent structs for the current struct and children.
+//!
+//! The order of attributes does not matter.
 //!
 //! For example:
 //! ```no_run
 //! structstruck::strike! {
-//!     #[structstruck::skip_each]
-//!     #[structstruck::each[Attr1]]
-//!     #[structstruck::clear_each]
-//!     #[structstruck::each[Attr2]]
 //!     struct A {
-//!         b: struct {}
+//!         #![structstruck::each[deny(unused)]]
+//!         b: struct {
+//!             #![structstruck::each[allow(unused)]]
+//!             #![structstruck::skip_each]
+//!             #![structstruck::clear_each]
+//!             c: struct {}
+//!         }
 //!     }
 //! }
+//! # const A: Option<A> = None;
+//! # fn foo() { A.unwrap().b; }
 //! ```
-//! will place no attributes on `A` and only `Attr2` on `B`.
+//! will place no attributes on `B` and only `allow(unused)` on `C`.
 //!
 //! #### Avoiding name collisions
 //! If you want include the parent struct name (or parent enum name and variant name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,27 @@
 //! println!("{:#?}", Parent { ..todo!("value skipped for brevity") });
 //! ```
 //!
+//! The behavior of `each` can be influenced in two ways:
+//!  * `structstruck::exclude_each` will ignore any attributes in `each`.
+//!    The order of attributes does not influence `exclude_each`.
+//!  * `structstruck::clear_each` will reset the set of attributes.
+//!    The order of atttributes matters.
+//!    After using `clear_each`, new attributes can be added.
+//!
+//! For example:
+//! ```no_run
+//! structstruck::strike! {
+//!     #[structstruck::skip_each]
+//!     #[structstruck::each[Attr1]]
+//!     #[structstruck::clear_each]
+//!     #[structstruck::each[Attr2]]
+//!     struct A {
+//!         b: struct {}
+//!     }
+//! }
+//! ```
+//! will place no attributes on `A` and only `Attr2` on `B`.
+//!
 //! #### Avoiding name collisions
 //! If you want include the parent struct name (or parent enum name and variant name)
 //! in the name of the child struct, add `#[structstruck::long_names]` to the struct.
@@ -235,7 +256,6 @@
 //! This is useful to prevent collisions when using the same field name multiple times or a type with the same name as a field exists.
 //!
 //! ### Missing features, limitations
-//!  * You can't exclude subtrees from `#[structstruck::each[…]]`.
 //!  * Generic parameter constraints need to be repeated for each struct.
 //!  * Usage error handling is minimal, e.g.:
 //!  * All substructs will be linearized directly next to the parent struct - without any namespacing or modules.  

--- a/src/test.rs
+++ b/src/test.rs
@@ -1047,8 +1047,8 @@ fn strikethrough_deprecated() {
 #[test]
 fn skip_reset() {
     let from = quote! {
-        #[structstruck::each[E1]]
         struct A {
+            #![structstruck::each[E1]]
             b: struct {
                 #![structstruck::each[E2]]
                 #![structstruck::clear_each]
@@ -1059,6 +1059,7 @@ fn skip_reset() {
         }
     };
     let out = quote! {
+        #[E2]
         #[E3]
         struct C {}
         struct B {
@@ -1070,8 +1071,11 @@ fn skip_reset() {
         }
     };
     check(from, out);
+}
 
-    let from = quote!{
+#[test]
+fn skip() {
+    let from = quote! {
         #[structstruck::each[OnAllMinusC]]
         struct A {
             b: struct B {
@@ -1081,7 +1085,7 @@ fn skip_reset() {
             }
         }
     };
-    let out = quote!{
+    let out = quote! {
         struct C {}
         #[OnAllMinusC]
         struct B {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1043,3 +1043,31 @@ fn strikethrough_deprecated() {
     assert!(out.contains("deprecated"));
     assert!(out.contains("structstruck::each"));
 }
+
+#[test]
+fn skip_reset() {
+    let from = quote! {
+        #[structstruck::each[E1]]
+        struct A {
+            b: struct {
+                #![structstruck::each[E2]]
+                #![structstruck::clear_each]
+                #![structstruck::each[E3]]
+                #![structstruck::skip_each]
+                c: struct C {}
+            }
+        }
+    };
+    let out = quote! {
+        #[E3]
+        struct C {}
+        struct B {
+            c: C
+        }
+        #[E1]
+        struct A {
+            b: B
+        }
+    };
+    check(from, out);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1070,4 +1070,27 @@ fn skip_reset() {
         }
     };
     check(from, out);
+
+    let from = quote!{
+        #[structstruck::each[OnAllMinusC]]
+        struct A {
+            b: struct B {
+                c:
+                #[structstruck::skip_each]
+                struct C {}
+            }
+        }
+    };
+    let out = quote!{
+        struct C {}
+        #[OnAllMinusC]
+        struct B {
+            c: C,
+        }
+        #[OnAllMinusC]
+        struct A {
+            b: B,
+        }
+    };
+    check(from, out);
 }


### PR DESCRIPTION
Add a new attribute named `nostrike` that allows you to skip subtrees for `strikethrough`.  

initial discussion in #9