### PR TITLE
implement here_each for setting the position of #[each] items

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -488,8 +488,19 @@ fn strike_through_attributes(
         true
     });
 
+    let mut pos = 0;
+    let mut each_pos = 0;
+    dec_attrs.retain(|attr| {
+        if check_crate_attr_no_params(attr, "here_each", ret) {
+            each_pos = pos;
+            return false;
+        }
+        pos += 1;
+        true
+    });
+
     if !skip_each {
-        dec_attrs.splice(0..0, strike_attrs.iter().cloned());
+        dec_attrs.splice(each_pos..each_pos, strike_attrs.iter().cloned());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,9 +202,9 @@
 //! The behavior of `each` can be influenced in three ways:
 //!  * `structstruck::skip_each` will ignore any attributes in `each` for the current struct only.
 //!  * `structstruck::clear_each` will ignore any `structstruck::each` from parent structs for the current struct and children.
-//! *  `structstruck::here_each` will set the position of the items inserted with `structstruck::each` in case order matters.
+//!  * `structstruck::here_each` will set the position of the items inserted with `structstruck::each` if attribute order matters.
 //!
-//! The order of attributes does not matter.
+//! The order of attributes (except for here_each) does not matter.
 //!
 //! For example:
 //! ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,9 +199,10 @@
 //! println!("{:#?}", Parent { ..todo!("value skipped for brevity") });
 //! ```
 //!
-//! The behavior of `each` can be influenced in two ways:
+//! The behavior of `each` can be influenced in three ways:
 //!  * `structstruck::skip_each` will ignore any attributes in `each` for the current struct only.
 //!  * `structstruck::clear_each` will ignore any `structstruck::each` from parent structs for the current struct and children.
+//! *  `structstruck::here_each` will set the position of the items inserted with `structstruck::each` in case order matters.
 //!
 //! The order of attributes does not matter.
 //!
@@ -222,6 +223,19 @@
 //! # fn foo() { A.unwrap().b; }
 //! ```
 //! will place no attributes on `B` and only `allow(unused)` on `C`.
+//!
+//! ```no_run
+//! strike!(
+//!     #[structstruck::each[B]]
+//!     #[structstruck::each[C]]
+//!
+//!     #[A]
+//!     #[structstruck::here_each]
+//!     #[D]
+//!     struct X {}
+//! );
+//! ```
+//! will place the attributes `#[A] #[B] #[C] #[D]` in that order.
 //!
 //! #### Avoiding name collisions
 //! If you want include the parent struct name (or parent enum name and variant name)

--- a/src/test.rs
+++ b/src/test.rs
@@ -1178,3 +1178,24 @@ fn array_degraded() {
     };
     check(from, out);
 }
+
+#[test]
+fn here_each() {
+    let from = quote! {
+        #[structstruck::each[B]]
+        #[structstruck::each[C]]
+
+        #[A]
+        #[structstruck::here_each]
+        #[D]
+        struct X {}
+    };
+    let out = quote! {
+        #[A]
+        #[B]
+        #[C]
+        #[D]
+        struct X {}
+    };
+    check(from, out);
+}


### PR DESCRIPTION
Motivation: Some attribute macros have to be in the right order, or they will crash. For example:

```rust
use spire_enum::prelude::*;
use structstruck::strike;

strike!(
    #[structstruck::each[derive(Clone, Debug)]]

    #[delegated_enum(impl_conversions, extract_variants(derive(Clone, Debug)))]
    enum Expression {
        Null {}
        AttrSet(Vec<struct Attribute {
            name: String,
            value: String
        }>)
    }
);
```

This expands to 

```rust
#[derive(Clone, Debug)]
struct Attribute {
    name: String,
    value: String,
}

#[derive(Clone, Debug)]
#[delegated_enum(impl_conversions, extract_variants(derive(Clone, Debug)))]
enum Expression {
    Null {},
    AttrSet(Vec<Attribute>),
}
```

which unfortunately causes an error in spire_enum due to the order of the attributes. There's currently no way to work around this while using each, so this adds a simple attribute to control the insertion point of the each attributes:

```rust
strike!(
    #[structstruck::each[B]]
    #[structstruck::each[C]]

    #[A]
    #[structstruck::here_each]
    #[D]
    struct X {}
);
```
will place the attributes `#[A] #[B] #[C] #[D]` in that order.
